### PR TITLE
Add custom error message to EmeraldDateFieldError

### DIFF
--- a/EmeraldIOS.podspec
+++ b/EmeraldIOS.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |spec|
   spec.resources = 'Resources/Images/*.png'
   spec.resource_bundles  = { "Resources" => ["Resources/Fonts/*.ttf", "Resources/Images/*.png"] }
   spec.name                 = "EmeraldIOS"
-  spec.version              = "1.3.4"
+  spec.version              = "1.3.41"
   spec.summary              = "Custom widgets management"
   spec.description          = "Custom widgets management."
   spec.homepage             = "https://github.com/cebroker/emerald-ios.git"

--- a/EmeraldIOS.xcodeproj/project.pbxproj
+++ b/EmeraldIOS.xcodeproj/project.pbxproj
@@ -1161,7 +1161,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.4;
+				MARKETING_VERSION = 1.3.41;
 				PRODUCT_BUNDLE_IDENTIFIER = io.condorlabs.EmeraldIOS;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1192,7 +1192,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.4;
+				MARKETING_VERSION = 1.3.41;
 				PRODUCT_BUNDLE_IDENTIFIER = io.condorlabs.EmeraldIOS;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/EmeraldIOS/Components/Date/EmeraldDateField.swift
+++ b/EmeraldIOS/Components/Date/EmeraldDateField.swift
@@ -32,6 +32,13 @@ public protocol EmeraldDateFieldTestableType {
 @IBDesignable
 public class EmeraldDateField: EmeraldTextField, EmeraldDateFieldType, EmeraldDateFieldTestableType {
     
+    public class ErrorMessages {
+        public var minimumDate = "Picked date is lower than minimum."
+        public var maximumDate = "Picked date is greater than maximum."
+        public var invalidFormat = "Invalid date format"
+    }
+    
+    public let errorMessages = ErrorMessages()
     private var selectedDate: Date?
     private lazy var dateFormatter: DateFormatter = DateFormatter()
     private weak var notifiable: EmeraldDateFieldChangeNotifiable?
@@ -64,23 +71,23 @@ public class EmeraldDateField: EmeraldTextField, EmeraldDateFieldType, EmeraldDa
         }
         
         guard let date = self.selectedDate else {
-            return .failure(EmeraldDateFieldError.invalidDateFormat)
+            return .failure(EmeraldDateFieldError.invalidDateFormat(message: errorMessages.invalidFormat))
         }
         
         if let minimumDate = self.minimumDate {
             guard date >= minimumDate else {
-                return .failure(EmeraldDateFieldError.lowerThanMinimumDate)
+                return .failure(EmeraldDateFieldError.lowerThanMinimumDate(message: errorMessages.minimumDate))
             }
         }
         
         if let maximumDate = self.maximumDate {
             guard date <= maximumDate else {
-                return .failure(EmeraldDateFieldError.greaterThanMaximumDate)
+                return .failure(EmeraldDateFieldError.greaterThanMaximumDate(message: errorMessages.maximumDate))
             }
         }
         
         guard let _ = getDate(from: text) else {
-            return .failure(EmeraldDateFieldError.invalidDateFormat)
+            return .failure(EmeraldDateFieldError.invalidDateFormat(message: errorMessages.invalidFormat))
         }
         
         return .success(true)

--- a/EmeraldIOS/Components/Date/EmeraldDateFieldError.swift
+++ b/EmeraldIOS/Components/Date/EmeraldDateFieldError.swift
@@ -7,20 +7,18 @@
 //
 
 enum EmeraldDateFieldError: FormFieldErrorType, Error {
-    case lowerThanMinimumDate
-    case greaterThanMaximumDate
-    case invalidDateFormat
+    case lowerThanMinimumDate(message: String)
+    case greaterThanMaximumDate(message: String)
+    case invalidDateFormat(message: String)
 }
 
 extension EmeraldDateFieldError {
     public var description: String? {
         switch self {
-        case .lowerThanMinimumDate:
-            return "Picked date is lower than minimum."
-        case .greaterThanMaximumDate:
-            return "Picked date is greater than maximum."
-        case .invalidDateFormat:
-            return "Invalid date format"
+        case .lowerThanMinimumDate(let message),
+             .greaterThanMaximumDate(let message),
+             .invalidDateFormat(let message):
+            return message
         }
     }
 }

--- a/ProofOfConcept/ProofOfConcept/ViewController.swift
+++ b/ProofOfConcept/ProofOfConcept/ViewController.swift
@@ -119,6 +119,9 @@ class ViewController: UIViewController, EmeraldValidableType {
         emeraldSelectorByStory.set(notifiable: self)
         emeraldStartDateFieldByStory.setDependantField(with: emeraldEndDateFieldByStory)
         emeraldStartDateFieldByStory.set(notifiable: emeraldStartDateFieldByStory)
+        emeraldStartDateFieldByStory.errorMessages.minimumDate = "This is a custom error"
+        emeraldStartDateFieldByStory.set(format: .shortDate)
+        emeraldStartDateFieldByStory.set(minimumDate: Date())
         emeraldTextView.set(placeholder: "Description")
         textViewStack.setPlaceholder(with: "Description")
         textViewStack.setTitle(with: "My textview title with an a large extension to probe if the multiples line split work.")


### PR DESCRIPTION
Add custom error messages to the emeraldDateFields

Now, if you want to add a custom error message instead of default messages, just edit the properties on the new class ErrorMessages within EmeraldDateTextfield.

e.g:

![image](https://user-images.githubusercontent.com/46906449/66863777-5f35cd00-ef59-11e9-9c58-b97b2863c065.png)

Result:
<img width="411" alt="Screen Shot 2019-10-15 at 2 31 50 PM" src="https://user-images.githubusercontent.com/46906449/66863745-4f1ded80-ef59-11e9-9c4f-8797fcf399bb.png">
