### PR TITLE
fix bug for load the options in the selector spinner

### DIFF
--- a/EmeraldIOS/Components/Selector/EmeraldSelectorField.swift
+++ b/EmeraldIOS/Components/Selector/EmeraldSelectorField.swift
@@ -193,7 +193,6 @@ public class EmeraldSelectorField: EmeraldTextField, EmeraldSelectorFieldType, U
         text = self.selectedRow?.getSelectableText()
         resignFirstResponder()
         toolbar.removeFromSuperview()
-        pickerView.removeFromSuperview()
 
         if let selectedRow = self.selectedRow {
             notifiable?.onSelected(row: selectedRow, from: self)


### PR DESCRIPTION
this pr fix the bug when the user select several times a selector field and the options is no loader, see image 

![Screen Shot 2020-04-14 at 11 29 15 AM](https://user-images.githubusercontent.com/48211003/79260831-8449c080-7e54-11ea-9c37-dd8ccbec8765.png)
